### PR TITLE
isFile should be called to get the result

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ spawn = function(options, callback) {
 };
 
 isFile = function(filePath) {
-    return fs.existsSync(filePath) && fs.statSync(filePath).isFile;
+    return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
 };
 
 getApmPath = function() {


### PR DESCRIPTION
reproduce the bug: call `isFile` on an existed directory like `electron.app`, that we will get a `[Function isFile]` not the `bool` value.

/cc @nantas 
